### PR TITLE
 test: Create customized logger to log warnings and errors on committed files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,19 @@ jobs:
           command: |               
             .\tunnel\build.cmd
       - run: 
+        name: Build Logger
+        command: |
+            cd test/logger
+            nuget install packages.config -OutputDirectory packages
+            csc -target:library SALogger.cs /reference:".\packages\Microsoft.Build.Utilities.Core.16.3.0\lib\net472\Microsoft.Build.Utilities.Core.dll;.\packages\Microsoft.Build.Framework.16.3.0\lib\net472\Microsoft.Build.Framework.dll;.\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll"  
+      - run: 
           name: Build Application
           command: |
             cd ui
             nuget restore -SolutionDirectory ./ 
-            MSBuild /t:Rebuild /p:Configuration=Release /p:Platform="x64" 
-            MSBuild /t:Rebuild /p:Configuration=Release /p:Platform="x86"
-            MSBuild /t:Rebuild /p:Configuration=Debug_QA /p:Platform="x64"
+            MSBuild -t:Rebuild -p:Configuration=Release -p:Platform="x64" -logger:"..\test\logger\SALogger.dll;..\test\logger\Output.log"
+            MSBuild -t:Rebuild -p:Configuration=Release -p:Platform="x86"
+            MSBuild -t:Rebuild -p:Configuration=Debug_QA -p:Platform="x64"
       - run: 
           name: Build MSI
           command: |
@@ -56,19 +62,33 @@ jobs:
       - run:
           name: Generate Tests Report
           command: |
-            ui\packages\extent.0.0.3\tools\extent.exe -i test\result\unittests\result.xml -o test\result\unittests
-            .\ui\coverage.bat
-            New-Item -ItemType directory -Path test\result\integration-tests
-            cd test
-            go get -u github.com/jstemmer/go-junit-report
-            Get-Content -Path test.out | C:\Users\circleci\go\bin\go-junit-report > ./result/integration-tests/report.xml
-            cd result\integration-tests
-            Get-Content report.xml | Set-Content -Encoding utf8 report-utf8.xml
-            Remove-Item report.xml
-            npm config set unsafe-perm true
-            npm i -g xunit-viewer@5.1.11
-            xunit-viewer --results=report-utf8.xml --output=report.html
-            Copy-Item "C:\Users\circleci\AppData\Local\Mozilla\FirefoxPrivateNetworkVPN\log.bin" -Destination "..\"
+            If ([System.IO.File]::Exists("test\result\unittests\result.xml")) {
+              # unit test report
+              ui\packages\extent.0.0.3\tools\extent.exe -i test\result\unittests\result.xml -o test\result\unittests;
+              # code coverage report
+              .\ui\coverage.bat
+            }
+            # integration test report
+            If ([System.IO.File]::Exists("test\test.out")) {
+              New-Item -ItemType directory -Path test\result\integration-tests;
+              cd test;
+              go get -u github.com/jstemmer/go-junit-report;
+              Get-Content -Path test.out | C:\Users\circleci\go\bin\go-junit-report > ./result/integration-tests/report.xml;
+              cd result\integration-tests;
+              Get-Content report.xml | Set-Content -Encoding utf8 report-utf8.xml;
+              Remove-Item report.xml;
+              npm config set unsafe-perm true;
+              npm i -g xunit-viewer@5.1.11;
+              xunit-viewer --results=report-utf8.xml --output=report.html;
+            }
+            # save application log
+            If ([System.IO.File]::Exists("C:\Users\circleci\AppData\Local\Mozilla\FirefoxPrivateNetworkVPN\log.bin")) {
+              Copy-Item "C:\Users\circleci\AppData\Local\Mozilla\FirefoxPrivateNetworkVPN\log.bin" -Destination "..\"
+            }
+            # add comments to PR if there are any warnings or errors on committed files
+            cd ../../test/comment
+            npm i
+            node comment.js
           when: always
       - run:
           name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ wireguard.server.base64.config
 
 #vim
 *.swp
+
+#logger
+test/logger/packages
+
+#comment
+test/comment/node_modules

--- a/test/comment/index.js
+++ b/test/comment/index.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const bot = require("circle-github-bot").create();
+const fs = require('fs');
+
+const path = '../logger/Output.log'
+fs.readFile(path, (err, data) => {
+    if(err) {
+        console.log(`Fail to read file: ${path}, err: ${err.message}`)
+    }
+    if(data.length > 0) {
+        console.log(data.toString())
+        bot.comment(`
+        <h3>Warnings</h3>
+        ${data}
+        `);
+    } else {
+        console.log('no warnings or errors')
+    }
+})
+

--- a/test/comment/package-lock.json
+++ b/test/comment/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "circle-github-bot": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/circle-github-bot/-/circle-github-bot-2.0.1.tgz",
+      "integrity": "sha512-uTEX8RIjUVdvtILxEG3AXI2G9X0wZYrN/Y67IIvrosjM/nt/QBdogpDXbkVsNQmhmQYqqFguWUgt50z6UMIoXw=="
+    }
+  }
+}

--- a/test/comment/package.json
+++ b/test/comment/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "comment",
+  "version": "1.0.0",
+  "description": "",
+  "main": "comment.js",
+  "dependencies": {
+    "circle-github-bot": "^2.0.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/logger/SALogger.cs
+++ b/test/logger/SALogger.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Management.Automation;
+using System.Security;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace SALogger
+{
+    // This logger will derive from the Microsoft.Build.Utilities.Logger class,
+    // which provides it with getters and setters for Verbosity and Parameters,
+    // and a default empty Shutdown() implementation.
+    public class SALogger : Logger
+    {
+        /// <summary>
+        /// Initialize is guaranteed to be called by MSBuild at the start of the build
+        /// before any events are raised.
+        /// </summary>
+        public override void Initialize(IEventSource eventSource)
+        {
+            // The name of the log file should be passed as the first item in the
+            // "parameters" specification in the /logger switch.  It is required
+            // to pass a log file to this logger. Other loggers may have zero or more than 
+            // one parameters.
+            if (null == Parameters)
+            {
+                throw new LoggerException("Log file was not set.");
+            }
+            string[] parameters = Parameters.Split(';');
+
+            string logFile = parameters[0];
+            if (String.IsNullOrEmpty(logFile))
+            {
+                throw new LoggerException("Log file was not set.");
+            }
+
+            if (parameters.Length > 1)
+            {
+                throw new LoggerException("Too many parameters passed.");
+            }
+
+            try
+            {
+                // Open the file
+                this.streamWriter = new StreamWriter(logFile);
+            }
+            catch (Exception ex)
+            {
+                if
+                (
+                    ex is UnauthorizedAccessException
+                    || ex is ArgumentNullException
+                    || ex is PathTooLongException
+                    || ex is DirectoryNotFoundException
+                    || ex is NotSupportedException
+                    || ex is ArgumentException
+                    || ex is SecurityException
+                    || ex is IOException
+                )
+                {
+                    throw new LoggerException("Failed to create log file: " + ex.Message);
+                }
+                else
+                {
+                    // Unexpected failure
+                    throw;
+                }
+            }
+            // string directory = "C:\\Users\\MiaoHuang\\Projects\\guardian-vpn"; // directory of the git repository
+            // Get the files that had changes in the last commit 
+            GetLastCommitChanges();
+
+            // For brevity, we'll only register for certain event types. Loggers can also
+            // register to handle TargetStarted/Finished and other events.
+            eventSource.WarningRaised += new BuildWarningEventHandler(eventSource_WarningRaised);
+            eventSource.ErrorRaised += new BuildErrorEventHandler(eventSource_ErrorRaised);
+        }
+
+        void eventSource_ErrorRaised(object sender, BuildErrorEventArgs e)
+        {
+            // BuildErrorEventArgs adds LineNumber, ColumnNumber, File, amongst other parameters
+            string line = String.Format(": ERROR {0}({1},{2}): ", e.File, e.LineNumber, e.ColumnNumber);
+            WriteLineWithSenderAndMessage(line, e);
+        }
+
+        void eventSource_WarningRaised(object sender, BuildWarningEventArgs e)
+        {
+            foreach(PSObject file in this.results)
+            {
+                string lastCommitFile = file.ToString().Replace("/", @"\");
+
+                if(lastCommitFile.Contains(e.File))
+                {
+                    // BuildWarningEventArgs adds LineNumber, ColumnNumber, File, amongst other parameters
+                    string line = String.Format(": Warning {0}({1},{2}): ", e.File, e.LineNumber, e.ColumnNumber);
+                    WriteLineWithSenderAndMessage(line, e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write a line to the log, adding the SenderName and Message
+        /// (these parameters are on all MSBuild event argument objects)
+        /// </summary>
+        private void WriteLineWithSenderAndMessage(string line, BuildEventArgs e)
+        {
+            if (0 == String.Compare(e.SenderName, "MSBuild", true /*ignore case*/))
+            {
+                // Well, if the sender name is MSBuild, let's leave it out for prettiness
+                WriteLine(line, e);
+            }
+            else
+            {
+                WriteLine(e.SenderName + ": " + line, e);
+            }
+        }
+
+        /// <summary>
+        /// Just write a line to the log
+        /// </summary>
+        private void WriteLine(string line, BuildEventArgs e)
+        {
+            streamWriter.WriteLine(line + e.Message);
+        }
+
+        private void GetLastCommitChanges()
+        {
+            using (PowerShell powershell = PowerShell.Create())
+            {
+                powershell.AddScript("cd ..");
+                powershell.AddScript(@"git diff-tree --no-commit-id --name-only -r HEAD");
+                results = powershell.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Shutdown() is guaranteed to be called by MSBuild at the end of the build, after all 
+        /// events have been raised.
+        /// </summary>
+        public override void Shutdown()
+        {
+            // Done logging, let go of the file
+            streamWriter.Close();
+        }
+
+        private StreamWriter streamWriter;
+        private Collection<PSObject> results;
+    }
+}

--- a/test/logger/packages.config
+++ b/test/logger/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Build.Utilities.Core" version="16.3.0" targetFramework="net472" />
+  <package id="Microsoft.Build.Framework" version="16.3.0" targetFramework="net472" />
+  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0"/>
+</packages>

--- a/ui/src/Windows/WlanApi.cs
+++ b/ui/src/Windows/WlanApi.cs
@@ -291,6 +291,7 @@ namespace FirefoxPrivateNetwork.Windows
             IhvStart = 0x30000000,
             IhvEnd = 0x3fffffff,
             #pragma warning restore SA1602 // EnumerationItemsMustBeDocumented
+
         }
 
         /// <summary>


### PR DESCRIPTION
As we are using StyleCop Anyalyzer to lint C# code, we want to show warnings and errors in the last committed files for every PR request. We create a customized logger "SALogger" to log warnings and errors in last committed files instead of all files in the whole project. After we get the logs, we send it back to PR as comments.