### PR TITLE
test: set up AWS EC2 to do smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,31 @@ jobs:
           path: test/result
       - store_artifacts:
           path: test/result
+  smoke-test:
+    executor:
+      name: win/vs2019
+      shell: powershell.exe
+    environment:
+      GO111MODULE: "on"
+    steps:
+      - run: 
+          name: Install AWSTool
+          command: |
+            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+            Install-Module -Name AWS.Tools.S3,AWS.Tools.CloudFormation -Scope AllUsers -Force
+      - run:
+          name: Upload To S3
+          command: |
+            Write-S3Object -BucketName $env:S3_BUCKET -File test/result/FirefoxPrivateNetworkVPN.msi -Key msi/$env:CIRCLE_BUILD_NUM/FirefoxPrivateNetworkVPN.msi
+      - run: 
+          name: Launch EC2 Win10
+          command: |
+            ./test/smoke/aws/create_ec2.ps1
+      # - run:
+      #     name: Clean Up
+      #     command: |
+      #       ./test/smoke/aws/terminate_ec2.ps1
+      #     when: always
 workflows:
   nightly:
     triggers:
@@ -118,4 +143,20 @@ workflows:
   workflow:
     jobs:
       - build
+      - smoke-test:
+          requires:
+            - build
+  smoke-test:
+    triggers:
+      - schedule:
+          cron: "0 */12 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build
+      - smoke-test:
+          requires:
+            - build
 

--- a/test/smoke/aws/create_ec2.ps1
+++ b/test/smoke/aws/create_ec2.ps1
@@ -1,0 +1,16 @@
+$p1 = new-object Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="KeyName"; ParameterValue="$env:KEY_NAME"}
+$p2 = new-object Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="GitBranch"; ParameterValue="$env:CIRCLE_BRANCH"}
+$p3 = new-object Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="S3BucketName"; ParameterValue="$env:S3_BUCKET"}
+$p4 = new-object Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="ImageId"; ParameterValue="$env:IMAGE_ID"}
+$p5 = new-object Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="BuildNumber"; ParameterValue="$env:CIRCLE_BUILD_NUM"}
+$params = @($p1,$p2,$p3,$p4,$p5)
+
+# validate cloudformation template
+$content = Get-Content -Path .\template.json -Raw
+Test-CFNTemplate -TemplateBody $content
+
+# create stack
+New-CFNStack -StackName guardian-stack-$env:CIRCLE_BUILD_NUM -TemplateBody $content -Capability CAPABILITY_IAM -Parameter $params
+
+# wait stack to complete
+Wait-CFNStack -StackName guardian-stack-$env:CIRCLE_BUILD_NUM

--- a/test/smoke/aws/template.json
+++ b/test/smoke/aws/template.json
@@ -1,0 +1,206 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "AWS CloudFormation Sample Template EC2InstanceWithSecurityGroupSample: Create an Amazon EC2 instance running the Amazon Linux AMI. The AMI is chosen based on the region in which the stack is run. This example creates an EC2 security group for the instance to give you SSH access. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.",
+
+  "Parameters" : {
+    "KeyName": {
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
+    },
+
+    "InstanceType" : {
+      "Description" : "WebServer EC2 instance type",
+      "Type" : "String",
+      "Default" : "t2.medium",
+      "AllowedValues" : [ "t1.micro", "t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large", "m1.small", "m1.medium", "m1.large", "m1.xlarge", "m2.xlarge", "m2.2xlarge", "m2.4xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "c1.medium", "c1.xlarge", "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge", "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge", "g2.2xlarge", "g2.8xlarge", "r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge", "i2.xlarge", "i2.2xlarge", "i2.4xlarge", "i2.8xlarge", "d2.xlarge", "d2.2xlarge", "d2.4xlarge", "d2.8xlarge", "hi1.4xlarge", "hs1.8xlarge", "cr1.8xlarge", "cc2.8xlarge", "cg1.4xlarge"],
+      "ConstraintDescription" : "must be a valid EC2 instance type."
+    },
+
+    "IPLocation" : {
+      "Description" : "The IP address range that can be used to RDP, Http, Https to the EC2 instances",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
+    "ImageId": {
+      "Description" : "AWS AMI Id",
+      "Type": "String"
+    },
+    "BuildNumber": {
+      "Description" : "CIRCLE_BUILD_NUM",
+      "Type": "String"
+    },
+    "S3BucketName": {
+      "Description" : "S3 Bucket Name",
+      "Type": "String"
+    }
+  },
+
+  "Resources" : {
+    "EC2Instance" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "InstanceType" : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
+        "KeyName" : { "Ref" : "KeyName" },
+        "ImageId" : { "Ref" : "ImageId" },
+        "IamInstanceProfile" : {
+          "Ref" : "ReadS3BucketsInstanceProfile"
+        },
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "<powershell>\n",
+                "Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False \n",
+                "New-ItemProperty -Path “HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows Defender” -Name DisableAntiSpyware -Value 1 -PropertyType DWORD -Force \n",             
+                "[Environment]::SetEnvironmentVariable('BUILD_NUMBER', '",
+                {
+                  "Ref": "BuildNumber"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "[Environment]::SetEnvironmentVariable('S3_BUCKET', '",
+                {
+                  "Ref": "S3BucketName"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "$env:BUILD_NUMBER = [System.Environment]::GetEnvironmentVariable(\"BUILD_NUMBER\",\"Machine\") \n",
+                "$env:S3_BUCKET = [System.Environment]::GetEnvironmentVariable(\"S3_BUCKET\",\"Machine\") \n",
+
+                "Write-Host 'Start downloading the repo...'\n",
+                "Invoke-WebRequest -Uri https://github.com/mozilla-services/guardian-vpn-windows/archive/master.zip -OutFile app.zip \n",
+                "Expand-Archive -LiteralPath app.zip -DestinationPath . \n",
+                "Write-Host Downloaded!\n",              
+
+                "Write-Host 'Start Installing MSI' \n",
+                "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force \n",
+                "Install-Module -Name AWS.Tools.S3 -Scope AllUsers -Force \n",
+                "Read-S3Object -BucketName $env:S3_BUCKET -Key msi/$env:BUILD_NUMBER/FirefoxPrivateNetworkVPN.msi -File FirefoxPrivateNetworkVPN.msi \n",
+                "Start-Process msiexec.exe -Wait -ArgumentList '/I C:\\Users\\Administrator\\FirefoxPrivateNetworkVPN.msi /quiet' \n",  
+                "Write-Host 'Complete.' \n",
+
+                "Write-Host 'Add a new firewall inbound rule' \n",  
+                "New-NetFirewallRule -DisplayName \"Allow Inbound Port 80\" -Direction Inbound -LocalPort 80 -Protocol TCP -Action Allow \n",
+                "Write-Host 'Start Running the web server' \n",  
+                "Start-Process -FilePath \"powershell\" -ArgumentList \"cd C:\\Users\\Administrator\\guardian-vpn-windows-master\\test\\smoke\\webserver; go run .\" \n",
+                "Write-Host 'Complete.' \n",                 
+
+                "</powershell>"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "ReadS3BucketsInstanceProfile" : {
+      "Type" : "AWS::IAM::InstanceProfile",
+      "Properties" : {
+        "Path" : "/",
+        "Roles" : [
+          {
+            "Ref" : "ReadS3BucketsRole"
+          }
+        ]
+      }
+    },
+    "ReadS3BucketsPolicy" : {
+      "Type" : "AWS::IAM::Policy",
+      "Properties" : {
+        "PolicyName" : "ReadS3BucketsPolicy",
+        "PolicyDocument" : {
+          "Statement" : [
+            {
+              "Effect" : "Allow",
+              "Action" : [
+                "s3:GetObject"
+              ],
+              "Resource" :{
+                "Fn::Join": [
+                  "", [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "S3BucketName"
+                    },
+                    "/*"
+                  ]
+                ]
+              }
+            }
+          ]
+        },
+        "Roles" : [
+          {
+            "Ref" : "ReadS3BucketsRole"
+          }
+        ]
+      }
+    },
+    "ReadS3BucketsRole" : {
+      "Type" : "AWS::IAM::Role",
+      "Properties" : {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement" : [
+            {
+              "Effect" : "Allow",
+              "Principal" : {
+                "Service" : ["ec2.amazonaws.com"]
+              },
+              "Action" : [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path" : "/"
+      }
+    },
+    "InstanceSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable RDP, HTTP access via port 3389, 80, 8000",
+        "SecurityGroupIngress" : [ {
+          "IpProtocol" : "tcp",
+          "FromPort" : "3389",
+          "ToPort" : "3389",
+          "CidrIp" : { "Ref" : "IPLocation"}
+        },{
+          "IpProtocol" : "tcp",
+          "FromPort" : "80",
+          "ToPort" : "80",
+          "CidrIp" : { "Ref" : "IPLocation"}
+        },{
+          "IpProtocol" : "tcp",
+          "FromPort" : "8000",
+          "ToPort" : "8000",
+          "CidrIp" : { "Ref" : "IPLocation"}
+        } ]
+      }
+    }
+  },
+
+  "Outputs" : {
+    "InstanceId" : {
+      "Description" : "InstanceId of the newly created EC2 instance",
+      "Value" : { "Ref" : "EC2Instance" }
+    },
+    "AZ" : {
+      "Description" : "Availability Zone of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "AvailabilityZone" ] }
+    },
+    "PublicDNS" : {
+      "Description" : "Public DNSName of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicDnsName" ] }
+    },
+    "PublicIP" : {
+      "Description" : "Public IP address of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicIp" ] }
+    }
+  }
+}

--- a/test/smoke/aws/terminate_ec2.ps1
+++ b/test/smoke/aws/terminate_ec2.ps1
@@ -1,0 +1,4 @@
+# remove the stack
+Remove-CFNStack -StackName guardian-stack-$env:CIRCLE_BUILD_NUM
+# wait stack to delete completely
+Wait-CFNStack -StackName guardian-stack-$env:CIRCLE_BUILD_NUM -Status DELETE_COMPLETE

--- a/test/smoke/webserver/go.mod
+++ b/test/smoke/webserver/go.mod
@@ -1,0 +1,8 @@
+module webserver
+
+go 1.12
+
+require (
+	github.com/bitly/go-simplejson v0.5.0
+	github.com/gorilla/mux v1.7.3
+)

--- a/test/smoke/webserver/go.sum
+++ b/test/smoke/webserver/go.sum
@@ -1,0 +1,4 @@
+github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
+github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/test/smoke/webserver/server.go
+++ b/test/smoke/webserver/server.go
@@ -1,0 +1,93 @@
+package main
+
+// !! CRITICAL SECURITY NOTICE !!
+// WARNING: THIS SERVICE ENABLES ARBITRARY SHELL EXECUTION ON THE SERVER FOR REMOTE TEST EXECUTION
+// MUST NEVER BE EXPOSED WITHOUT RESTRICTED INBOUNDS IPs
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/bitly/go-simplejson"
+	"github.com/gorilla/mux"
+)
+
+type App struct {
+	Router *mux.Router
+}
+
+type Command struct {
+	Cmd  string `json:"cmd"`
+	Args string `json:"args"`
+	Dir  string `json:"dir"`
+	Key  string `json:"key"`
+}
+
+func (app *App) setupRouter() {
+	app.Router.
+		Methods("POST").
+		Path("/test").
+		HandlerFunc(app.postCommand)
+
+	app.Router.
+		Methods("GET").
+		Path("/").
+		HandlerFunc(app.getAlive)
+}
+
+func (app *App) getAlive(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func runCommand(cmdstr string, args []string, dir string) (stdout, stderr string) {
+	log.Println("Executing: " + cmdstr)
+	cmd := exec.Command(cmdstr, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		stderr = err.Error()
+	}
+	stdout = string(out)
+	return
+}
+
+func (app *App) postCommand(w http.ResponseWriter, r *http.Request) {
+	log.Println("Request received!")
+
+	response := simplejson.New()
+
+	var command Command
+	_ = json.NewDecoder(r.Body).Decode(&command)
+	args := strings.Split(command.Args, " ")
+	log.Println("dir", command.Dir)
+
+	stdout, stderr := runCommand(command.Cmd, args,
+		command.Dir)
+
+	response.Set("out", stdout)
+	response.Set("err", stderr)
+
+	payload, err := response.MarshalJSON()
+	if err != nil {
+		log.Println(err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(payload)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func main() {
+	app := App{
+		Router: mux.NewRouter().StrictSlash(true),
+	}
+
+	app.setupRouter()
+
+	log.Fatal(http.ListenAndServe(":80", app.Router))
+}


### PR DESCRIPTION
In order to do smoke test, we need to simulate the real production environment which is in Windows 10. However the CircleCI is current using Windows server 2019 for all windows job and Windows server 2019 only has IE 11 installed. IE 11 is not supported by FxA anymore and cannot show user login web page properly. This is why we start using VM to do smoke test.