### PR TITLE
test: Add server selection UI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ workflows:
   workflow:
     jobs:
       - build
+      - smoke-test:
+          requires:
+            - build
   smoke-test:
     triggers:
       - schedule:

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/UserCommonOperation.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/UserCommonOperation.cs
@@ -5,9 +5,11 @@
 namespace FirefoxPrivateVPNUITest
 {
     using System;
+    using System.Net;
     using System.Threading;
     using FirefoxPrivateVPNUITest.Screens;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Polly;
     using RestSharp;
 
     /// <summary>
@@ -61,6 +63,8 @@ namespace FirefoxPrivateVPNUITest
         public static void UserSignOut(FirefoxPrivateVPNSession vpnClient)
         {
             vpnClient.Session.SwitchTo();
+            MainScreen mainScreen = new MainScreen(vpnClient.Session);
+            mainScreen.ClickSettingsButton();
             SettingScreen settingScreen = new SettingScreen(vpnClient.Session);
             Assert.AreEqual("Settings", settingScreen.GetTitle());
             settingScreen.ClickSignOutButton();
@@ -81,7 +85,133 @@ namespace FirefoxPrivateVPNUITest
             request.AddHeader("Host", "am.i.mullvad.net");
             request.AddHeader("Cache-Control", "no-cache");
             request.AddHeader("Accept", "*/*");
-            return client.Execute(request);
+            return RetryExecute(client, request);
+        }
+
+        /// <summary>
+        /// Call Mullvad API to get current city.
+        /// </summary>
+        /// <returns>The API response.</returns>
+        public static IRestResponse GetCityViaMullvad()
+        {
+            var client = new RestClient("https://am.i.mullvad.net/city");
+            var request = new RestRequest(Method.GET);
+            request.AddHeader("cache-control", "no-cache");
+            request.AddHeader("Connection", "keep-alive");
+            request.AddHeader("Accept-Encoding", "gzip, deflate");
+            request.AddHeader("Host", "am.i.mullvad.net");
+            request.AddHeader("Cache-Control", "no-cache");
+            request.AddHeader("Accept", "*/*");
+            return RetryExecute(client, request);
+        }
+
+        /// <summary>
+        /// User click the toggle switch to connect to VPN.
+        /// </summary>
+        /// <param name="vpnClient">VPN session.</param>
+        /// <param name="desktop">Desktop session.</param>
+        public static void ConnectVPN(FirefoxPrivateVPNSession vpnClient, DesktopSession desktop)
+        {
+            // Verify user is not connected to Mullvad VPN
+            IRestResponse response = AmIMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsTrue(response.Content.Contains("You are not connected to Mullvad"));
+
+            // Click VPN switch toggle and turn on VPN
+            vpnClient.Session.SwitchTo();
+            MainScreen mainScreen = new MainScreen(vpnClient.Session);
+            mainScreen.ToggleVPNSwitch();
+            Assert.AreEqual("Connecting...", mainScreen.GetTitle());
+            Assert.AreEqual("You will be protected shortly", mainScreen.GetSubtitle());
+            Assert.IsTrue(mainScreen.GetOnImage().Displayed);
+            Assert.IsFalse(mainScreen.GetOffImage().Displayed);
+
+            // Verify the windows notification
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            desktop.Session.SwitchTo();
+            WindowsNotificationScreen windowsNotificationScreen = new WindowsNotificationScreen(desktop.Session);
+            Assert.AreEqual("VPN is on", windowsNotificationScreen.GetTitleText());
+            Assert.AreEqual("You're secure and protected.", windowsNotificationScreen.GetMessageText());
+            windowsNotificationScreen.ClickDismissButton();
+
+            vpnClient.Session.SwitchTo();
+            Assert.AreEqual("VPN is on", mainScreen.GetTitle());
+            Assert.IsTrue(mainScreen.GetSubtitle().Contains("Secure and protected"));
+
+            // Verify user is connected to Mullvad VPN
+            response = AmIMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsTrue(response.Content.Contains("You are connected to Mullvad"));
+        }
+
+        /// <summary>
+        /// User click the toggle switch to turn off VPN.
+        /// </summary>
+        /// <param name="vpnClient">VPN session.</param>
+        /// <param name="desktop">Desktop session.</param>
+        public static void DisconnectVPN(FirefoxPrivateVPNSession vpnClient, DesktopSession desktop)
+        {
+            // Verify user is already connected to VPN
+            IRestResponse response = AmIMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsTrue(response.Content.Contains("You are connected to Mullvad"));
+
+            // Click VPN switch toggle and turn off VPN
+            vpnClient.Session.SwitchTo();
+            MainScreen mainScreen = new MainScreen(vpnClient.Session);
+            mainScreen.ToggleVPNSwitch();
+            Assert.AreEqual("Disconnecting...", mainScreen.GetTitle());
+            Assert.AreEqual("You will be disconnected shortly", mainScreen.GetSubtitle());
+            Assert.IsTrue(mainScreen.GetOffImage().Displayed);
+            Assert.IsFalse(mainScreen.GetOnImage().Displayed);
+
+            // Verify the windows notification
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            desktop.Session.SwitchTo();
+            WindowsNotificationScreen windowsNotificationScreen = new WindowsNotificationScreen(desktop.Session);
+            Assert.AreEqual("VPN is off", windowsNotificationScreen.GetTitleText());
+            Assert.AreEqual("You disconnected.", windowsNotificationScreen.GetMessageText());
+            windowsNotificationScreen.ClickDismissButton();
+
+            vpnClient.Session.SwitchTo();
+            Assert.AreEqual("VPN is off", mainScreen.GetTitle());
+            Assert.AreEqual("Turn it on to protect your entire device", mainScreen.GetSubtitle());
+
+            // Verify user disconnected to Mullvad VPN
+            response = AmIMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsTrue(response.Content.Contains("You are not connected to Mullvad"));
+        }
+
+        /// <summary>
+        /// Execute the request with retry policy.
+        /// </summary>
+        /// <param name="client">RestClient object.</param>
+        /// <param name="request">RestRequest object.</param>
+        /// <returns>The API response.</returns>
+        private static IRestResponse RetryExecute(IRestClient client, IRestRequest request)
+        {
+            // Define retry policy
+            var policy = Policy.HandleResult<IRestResponse>((response) =>
+            {
+                return response.StatusCode != HttpStatusCode.OK;
+            }).WaitAndRetry(3, (count) => TimeSpan.FromSeconds(count));
+
+            // Execute the request with policy
+            var val = policy.ExecuteAndCapture(() =>
+            {
+                return client.Execute(request);
+            });
+            IRestResponse rr = val.Result;
+
+            if (rr == null)
+            {
+                rr = new RestResponse();
+                rr.Request = request;
+                rr.ErrorException = val.FinalException;
+            }
+
+            return rr;
         }
     }
 }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/Utils.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/Utils.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="Utils.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using FirefoxPrivateVPNUITest.Screens;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using RestSharp;
+
+    /// <summary>
+    /// Here are some utilities.
+    /// </summary>
+    public class Utils
+    {
+        /// <summary>
+        /// Random select an index from integers based on the condition.
+        /// </summary>
+        /// <param name="range">A range of integers.</param>
+        /// <param name="condition">A condition method.</param>
+        /// <returns>A random index.</returns>
+        public static int RandomSelectIndex(IEnumerable<int> range, Func<int, bool> condition)
+        {
+            var result = range.Where(condition);
+            var rand = new Random();
+            int index = rand.Next(0, result.Count());
+            return result.ElementAt(index);
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.csproj
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.csproj
@@ -55,6 +55,9 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Polly, Version=7.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Polly.7.2.0\lib\net472\Polly.dll</HintPath>
+    </Reference>
     <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
     </Reference>
@@ -72,6 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\UserCommonOperation.cs" />
+    <Compile Include="Common\Utils.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -86,6 +90,7 @@
     <Compile Include="Screens\RegisterPage.cs" />
     <Compile Include="Screens\EmailInputPage.cs" />
     <Compile Include="Screens\LandingScreen.cs" />
+    <Compile Include="Screens\ServerListScreen.cs" />
     <Compile Include="Screens\SettingScreen.cs" />
     <Compile Include="Screens\VerifyAccountScreen.cs" />
     <Compile Include="Screens\WindowsNotificationScreen.cs" />
@@ -99,6 +104,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tests\NewUserSignInTest.cs" />
     <Compile Include="Tests\OnboardingScreenTest.cs" />
+    <Compile Include="Tests\ServerSelectTest.cs" />
+    <Compile Include="Tests\UtilsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/EmailInputPage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/EmailInputPage.cs
@@ -21,7 +21,7 @@ namespace FirefoxPrivateVPNUITest.Screens
         public EmailInputPage(WindowsDriver<WindowsElement> browserSession)
         {
             this.emailTextBox = browserSession.FindElementByName("Email");
-            this.continueButton = browserSession.FindElementByName("Continue");
+            this.continueButton = browserSession.FindElementByAccessibilityId("submit-btn");
         }
 
         /// <summary>

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/MainScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/MainScreen.cs
@@ -29,7 +29,7 @@ namespace FirefoxPrivateVPNUITest.Screens
             this.titleElement = vpnSession.FindElementByClassName("HeroText");
             this.subtitleElement = vpnSession.FindElementByClassName("HeroSubText");
             this.settingButton = vpnSession.FindElementByName("Settings");
-            this.vpnSwitch = vpnSession.FindElementByName("Toggle VPN");
+            this.vpnSwitch = vpnSession.FindElementByName("Toggle");
             this.serverListButton = vpnSession.FindElementByAccessibilityId("ConnectionNavButton");
             this.deviceListButton = vpnSession.FindElementByName("My devices");
             this.vpnStatus = vpnSession.FindElementByName("VPN status");

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/ServerListScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/ServerListScreen.cs
@@ -1,0 +1,141 @@
+﻿// <copyright file="ServerListScreen.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest.Screens
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// This model is for Setting screen.
+    /// </summary>
+    internal class ServerListScreen
+    {
+        private AppiumWebElement backButton;
+        private AppiumWebElement title;
+        private AppiumWebElement serverListView;
+        private AppiumWebElement selectedServerCountry;
+        private AppiumWebElement selectedServerCity;
+        private AppiumWebElement selectedServerCountryCityList;
+        private AppiumWebElement scrollDownButton;
+        private WindowsDriver<WindowsElement> vpnSession;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerListScreen"/> class.
+        /// </summary>
+        /// <param name="vpnSession">VPN session.</param>
+        public ServerListScreen(WindowsDriver<WindowsElement> vpnSession)
+        {
+            this.vpnSession = vpnSession;
+            this.scrollDownButton = vpnSession.FindElementByAccessibilityId("PART_LineDownButton");
+            this.backButton = vpnSession.FindElementByName("Back");
+            this.title = vpnSession.FindElementByName("Connection");
+            this.serverListView = vpnSession.FindElementByAccessibilityId("CountryServerList");
+            var countryList = this.serverListView.FindElementsByClassName("ListBoxItem");
+            foreach (var country in countryList)
+            {
+                if (this.selectedServerCountry != null && this.selectedServerCity != null)
+                {
+                    break;
+                }
+
+                if (country.Displayed)
+                {
+                    this.selectedServerCountry = country;
+                    var countryExpander = country.FindElementByClassName("Expander");
+                    var expandedState = countryExpander.FindElementByClassName("Button");
+                    if (!expandedState.Selected)
+                    {
+                        expandedState.Click();
+                    }
+
+                    this.selectedServerCountryCityList = countryExpander.FindElementByAccessibilityId("CityServerList");
+                    var cityList = this.selectedServerCountryCityList.FindElementsByClassName("ListBoxItem");
+                    foreach (var city in cityList)
+                    {
+                        var citySelection = city.FindElementByClassName("RadioButton");
+                        if (citySelection.Selected)
+                        {
+                            this.selectedServerCity = city;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get title on server selection screen.
+        /// </summary>
+        /// <returns>The title string.</returns>
+        public string GetTitle()
+        {
+            return this.title.Text;
+        }
+
+        /// <summary>
+        /// Click the Back button.
+        /// </summary>
+        public void ClickBackButton()
+        {
+            this.backButton.Click();
+        }
+
+        /// <summary>
+        /// Get the selected country name.
+        /// </summary>
+        /// <returns>Selected country name.</returns>
+        public string GetSelectedCountry()
+        {
+            return this.selectedServerCountry.GetAttribute("Name");
+        }
+
+        /// <summary>
+        /// Get selected city name.
+        /// </summary>
+        /// <returns>Selected city name.</returns>
+        public string GetSelectedCity()
+        {
+            return this.selectedServerCity.GetAttribute("Name");
+        }
+
+        /// <summary>
+        /// Random select a different city server in US.
+        /// </summary>
+        /// <param name="city">The city we want to select.</param>
+        public void RandomSelectDifferentCityServer(string city = null)
+        {
+            var cityList = this.selectedServerCountryCityList.FindElementsByClassName("ListBoxItem");
+            Func<int, bool> randomPickCondition = (i) =>
+            {
+                string currentCityName = cityList[i].GetAttribute("Name");
+                if (city == null)
+                {
+                    return currentCityName != this.GetSelectedCity();
+                }
+
+                return currentCityName != this.GetSelectedCity() && currentCityName.Contains(city);
+            };
+
+            int randomIndex = Utils.RandomSelectIndex(Enumerable.Range(0, cityList.Count), randomPickCondition);
+            var randomCity = cityList[randomIndex];
+            while (!randomCity.Displayed)
+            {
+                this.scrollDownButton.Click();
+                this.vpnSession.Mouse.MouseDown(null);
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+                this.vpnSession.Mouse.MouseUp(null);
+            }
+
+            // Click radio button to select the server
+            this.selectedServerCity = randomCity;
+            var citySelection = this.selectedServerCity.FindElementByClassName("RadioButton");
+            citySelection.Click();
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/WindowsNotificationScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/WindowsNotificationScreen.cs
@@ -5,6 +5,7 @@
 namespace FirefoxPrivateVPNUITest.Screens
 {
     using System;
+    using System.Threading;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -33,12 +34,13 @@ namespace FirefoxPrivateVPNUITest.Screens
             catch (Exception)
             {
                 desktopSession.FindElementByName("Action Center").Click();
+                Thread.Sleep(TimeSpan.FromSeconds(1));
                 var actionCenterWindow = desktopSession.FindElementByName("Action center");
                 var notification = actionCenterWindow.FindElementByName("Notifications from Firefox Private Network VPN");
                 var latestNotification = notification.FindElementByClassName("ListViewItem");
                 this.titleText = latestNotification.FindElementByAccessibilityId("Title");
                 this.messageText = latestNotification.FindElementByAccessibilityId("Content");
-                this.dismissButton = notification.FindElementByAccessibilityId("DismissButton");
+                this.dismissButton = latestNotification.FindElementByAccessibilityId("DismissButton");
             }
         }
 

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/BrowserSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/BrowserSession.cs
@@ -91,8 +91,15 @@ namespace FirefoxPrivateVPNUITest
             if (this.Session != null)
             {
                 this.Session.Close();
-                WindowsElement closeButton = this.Session.FindElementByName("Close Tabs");
-                closeButton.Click();
+                try
+                {
+                    WindowsElement closeButton = this.Session.FindElementByName("Close Tabs");
+                    closeButton.Click();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+
                 this.Session.Quit();
                 this.Session = null;
             }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
@@ -90,7 +90,6 @@ namespace FirefoxPrivateVPNUITest
                     }
 
                     Thread.Sleep(TimeSpan.FromSeconds(2));
-                    mainScreen.ClickSettingsButton();
                     UserCommonOperation.UserSignOut(this);
                 }
 

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ConnectTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ConnectTest.cs
@@ -65,61 +65,13 @@ namespace FirefoxPrivateVPNUITest
             Assert.IsTrue(mainScreen.GetOffImage().Displayed);
             Assert.IsFalse(mainScreen.GetOnImage().Displayed);
 
-            // Verify user is not connected to Mullvad VPN
-            IRestResponse response = UserCommonOperation.AmIMullvad();
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.IsTrue(response.Content.Contains("You are not connected to Mullvad"));
+            // User turns on VPN
+            UserCommonOperation.ConnectVPN(this.vpnClient, this.desktop);
 
-            // Click VPN switch toggle and turn on VPN
-            mainScreen.ToggleVPNSwitch();
-            Assert.AreEqual("Connecting...", mainScreen.GetTitle());
-            Assert.AreEqual("You will be protected shortly", mainScreen.GetSubtitle());
-            Assert.IsTrue(mainScreen.GetOnImage().Displayed);
-            Assert.IsFalse(mainScreen.GetOffImage().Displayed);
-
-            // Verify the windows notification
-            Thread.Sleep(TimeSpan.FromSeconds(2));
-            this.desktop.Session.SwitchTo();
-            WindowsNotificationScreen windowsNotificationScreen = new WindowsNotificationScreen(this.desktop.Session);
-            Assert.AreEqual("VPN is on", windowsNotificationScreen.GetTitleText());
-            Assert.AreEqual("You're secure and protected.", windowsNotificationScreen.GetMessageText());
-            windowsNotificationScreen.ClickDismissButton();
-
-            this.vpnClient.Session.SwitchTo();
-            Assert.AreEqual("VPN is on", mainScreen.GetTitle());
-            Assert.IsTrue(mainScreen.GetSubtitle().Contains("Secure and protected"));
-
-            // Verify user is connected to Mullvad VPN
-            response = UserCommonOperation.AmIMullvad();
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.IsTrue(response.Content.Contains("You are connected to Mullvad"));
-
-            // Click VPN switch toggle and turn off VPN
-            mainScreen.ToggleVPNSwitch();
-            Assert.AreEqual("Disconnecting...", mainScreen.GetTitle());
-            Assert.AreEqual("You will be disconnected shortly", mainScreen.GetSubtitle());
-            Assert.IsTrue(mainScreen.GetOffImage().Displayed);
-            Assert.IsFalse(mainScreen.GetOnImage().Displayed);
-
-            // Verify the windows notification
-            Thread.Sleep(TimeSpan.FromSeconds(2));
-            this.desktop.Session.SwitchTo();
-            windowsNotificationScreen = new WindowsNotificationScreen(this.desktop.Session);
-            Assert.AreEqual("VPN is off", windowsNotificationScreen.GetTitleText());
-            Assert.AreEqual("You disconnected.", windowsNotificationScreen.GetMessageText());
-            windowsNotificationScreen.ClickDismissButton();
-
-            this.vpnClient.Session.SwitchTo();
-            Assert.AreEqual("VPN is off", mainScreen.GetTitle());
-            Assert.AreEqual("Turn it on to protect your entire device", mainScreen.GetSubtitle());
-
-            // Verify user disconnected to Mullvad VPN
-            response = UserCommonOperation.AmIMullvad();
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.IsTrue(response.Content.Contains("You are not connected to Mullvad"));
+            // User turns off VPN
+            UserCommonOperation.DisconnectVPN(this.vpnClient, this.desktop);
 
             // Sign out
-            mainScreen.ClickSettingsButton();
             UserCommonOperation.UserSignOut(this.vpnClient);
         }
     }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ExistedUserSignInTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ExistedUserSignInTest.cs
@@ -56,7 +56,6 @@ namespace FirefoxPrivateVPNUITest
             this.vpnClient.Session.SwitchTo();
             MainScreen mainScreen = new MainScreen(this.vpnClient.Session);
             Assert.AreEqual("VPN is off", mainScreen.GetTitle());
-            mainScreen.ClickSettingsButton();
 
             // Setting Screen
             UserCommonOperation.UserSignOut(this.vpnClient);

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/OnboardingScreenTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/OnboardingScreenTest.cs
@@ -19,7 +19,7 @@ namespace FirefoxPrivateVPNUITest
         private BrowserSession browser;
 
         /// <summary>
-        /// Initialize vpn client sessions.
+        /// Initialize vpn client and browser sessions.
         /// </summary>
         [TestInitialize]
         public void TestInitialize()
@@ -87,7 +87,6 @@ namespace FirefoxPrivateVPNUITest
             this.vpnClient.Session.SwitchTo();
             MainScreen mainScreen = new MainScreen(this.vpnClient.Session);
             Assert.AreEqual("VPN is off", mainScreen.GetTitle());
-            mainScreen.ClickSettingsButton();
 
             // Setting Screen
             UserCommonOperation.UserSignOut(this.vpnClient);

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ServerSelectTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ServerSelectTest.cs
@@ -1,0 +1,152 @@
+﻿// <copyright file="ServerSelectTest.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using FirefoxPrivateVPNUITest.Screens;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// This is to test server selection.
+    /// </summary>
+    [TestClass]
+    public class ServerSelectTest
+    {
+        private FirefoxPrivateVPNSession vpnClient;
+        private BrowserSession browser;
+        private DesktopSession desktop;
+
+        /// <summary>
+        /// Initialize vpn client, browser, and desktop sessions.
+        /// </summary>
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.browser = new BrowserSession();
+            this.vpnClient = new FirefoxPrivateVPNSession();
+            this.desktop = new DesktopSession();
+        }
+
+        /// <summary>
+        /// Dispose vpn session, browser and desktop sessions.
+        /// </summary>
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            this.vpnClient.Dispose();
+            this.browser.Dispose();
+            this.desktop.Dispose();
+        }
+
+        /// <summary>
+        /// Test server selection before user turns on VPN.
+        /// </summary>
+        [TestMethod]
+        public void TestServerSelectionBeforeConnection()
+        {
+            // Switch to VPN client session
+            this.vpnClient.Session.SwitchTo();
+            LandingScreen landingScreen = new LandingScreen(this.vpnClient.Session);
+            landingScreen.ClickGetStartedButton();
+
+            // User Sign In via web browser
+            UserCommonOperation.UserSignIn(this.vpnClient, this.browser);
+
+            // Main Screen
+            this.vpnClient.Session.SwitchTo();
+            MainScreen mainScreen = new MainScreen(this.vpnClient.Session);
+            mainScreen.ClickServerListButton();
+
+            // Server Screen
+            ServerListScreen serverListScreen = new ServerListScreen(this.vpnClient.Session);
+            serverListScreen.RandomSelectDifferentCityServer("Miami");
+            string currentCity = serverListScreen.GetSelectedCity();
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+
+            // User turns on VPN
+            UserCommonOperation.ConnectVPN(this.vpnClient, this.desktop);
+
+            // Verify city via Mullvad API
+            var cityResponse = UserCommonOperation.GetCityViaMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, cityResponse.StatusCode);
+            Assert.IsTrue(currentCity.Contains(cityResponse.Content.Trim()));
+
+            // User turns off VPN
+            UserCommonOperation.DisconnectVPN(this.vpnClient, this.desktop);
+
+            // Sign out
+            UserCommonOperation.UserSignOut(this.vpnClient);
+        }
+
+        /// <summary>
+        /// Test server selection after user turns on VPN.
+        /// </summary>
+        [TestMethod]
+        public void TestServerSelectionAfterConnection()
+        {
+            // Switch to VPN client session
+            this.vpnClient.Session.SwitchTo();
+            LandingScreen landingScreen = new LandingScreen(this.vpnClient.Session);
+            landingScreen.ClickGetStartedButton();
+
+            // User Sign In via web browser
+            UserCommonOperation.UserSignIn(this.vpnClient, this.browser);
+
+            // Main Screen
+            this.vpnClient.Session.SwitchTo();
+            MainScreen mainScreen = new MainScreen(this.vpnClient.Session);
+            mainScreen.ClickServerListButton();
+
+            // Server Screen
+            ServerListScreen serverListScreen = new ServerListScreen(this.vpnClient.Session);
+            serverListScreen.RandomSelectDifferentCityServer("Miami");
+            string prevCity = serverListScreen.GetSelectedCity();
+            Console.WriteLine("Before switching: the selected city is {0}", prevCity);
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+
+            // User turns on VPN
+            UserCommonOperation.ConnectVPN(this.vpnClient, this.desktop);
+
+            // Verify city via Mullvad API
+            var cityResponse = UserCommonOperation.GetCityViaMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, cityResponse.StatusCode);
+            Assert.IsTrue(prevCity.Contains(cityResponse.Content.Trim()));
+
+            // Click the server button
+            mainScreen = new MainScreen(this.vpnClient.Session);
+            mainScreen.ClickServerListButton();
+
+            // Select a random US server
+            serverListScreen = new ServerListScreen(this.vpnClient.Session);
+            serverListScreen.RandomSelectDifferentCityServer("Atlanta");
+            string currentCity = serverListScreen.GetSelectedCity();
+            Console.WriteLine("After switching: the selected city is {0}", currentCity);
+
+            // Check the subtitle
+            Assert.AreEqual(string.Format("From {0} to {1}", prevCity, currentCity), mainScreen.GetSubtitle());
+
+            // Check the windows notification again
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            this.desktop.Session.SwitchTo();
+            WindowsNotificationScreen windowsNotificationScreen = new WindowsNotificationScreen(this.desktop.Session);
+            Assert.AreEqual(string.Format("From {0} to {1}", prevCity, currentCity), windowsNotificationScreen.GetTitleText());
+            Assert.AreEqual("You switched servers.", windowsNotificationScreen.GetMessageText());
+            windowsNotificationScreen.ClickDismissButton();
+
+            // Verify city via Mullvad API
+            cityResponse = UserCommonOperation.GetCityViaMullvad();
+            Assert.AreEqual(HttpStatusCode.OK, cityResponse.StatusCode);
+            Assert.IsTrue(currentCity.Contains(cityResponse.Content.Trim()));
+
+            // User turns off VPN
+            UserCommonOperation.DisconnectVPN(this.vpnClient, this.desktop);
+
+            // Sign out
+            UserCommonOperation.UserSignOut(this.vpnClient);
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/UtilsTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/UtilsTest.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="UtilsTest.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest
+{
+    using System.Linq;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// This is to test server selection.
+    /// </summary>
+    [TestClass]
+    public class UtilsTest
+    {
+        /// <summary>
+        /// Test RandomSelectIndex method.
+        /// </summary>
+        [TestMethod]
+        public void TestRandomSelectIndex()
+        {
+            int randomIndex1 = Utils.RandomSelectIndex(Enumerable.Range(0, 2), (number) => number != 1);
+            Assert.AreNotEqual(1, randomIndex1);
+
+            int randomIndex2 = Utils.RandomSelectIndex(Enumerable.Range(0, 2), (number) => number != 0);
+            Assert.AreNotEqual(0, randomIndex2);
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/packages.config
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/packages.config
@@ -5,6 +5,7 @@
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
+  <package id="Polly" version="7.2.0" targetFramework="net472" />
   <package id="RestSharp" version="106.10.1" targetFramework="net472" />
   <package id="Selenium.Support" version="3.8.0" targetFramework="net472" />
   <package id="Selenium.WebDriver" version="3.8.0" targetFramework="net472" />


### PR DESCRIPTION
We add two more UI tests for server selection. One scenario is that user
select server before turning on the VPN. The other one scenario is that
user select server after turning on the VPN. Meanwhile, we refactor some
code and try to prevent duplication.